### PR TITLE
[ecovacs] Add client keys and secrets to api instance

### DIFF
--- a/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/EcovacsApiHandler.java
+++ b/bundles/org.openhab.binding.ecovacs/src/main/java/org/openhab/binding/ecovacs/internal/EcovacsApiHandler.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
 
+import dev.pott.sucks.api.ClientKeys;
 import dev.pott.sucks.api.EcovacsApi;
 import dev.pott.sucks.api.EcovacsApiConfiguration;
 import dev.pott.sucks.api.EcovacsApiException;
@@ -48,7 +49,7 @@ public class EcovacsApiHandler extends BaseBridgeHandler {
 
     private @Nullable EcovacsDeviceDiscoveryService discoveryService;
     private @Nullable EcovacsApi api;
-    private HttpClientFactory httpClientFactory;
+    private final HttpClientFactory httpClientFactory;
 
     public EcovacsApiHandler(Bridge bridge, HttpClientFactory httpClientFactory) {
         super(bridge);
@@ -99,7 +100,8 @@ public class EcovacsApiHandler extends BaseBridgeHandler {
                     MD5Util.getMD5Hash(String.valueOf(System.currentTimeMillis())), // FIXME: unique install ID
                     config.email, config.password,
                     // FIXME: can get this from locale?
-                    "EU", "DE", "EN");
+                    "EU", "DE", "EN", ClientKeys.CLIENT_KEY, ClientKeys.CLIENT_SECRET, ClientKeys.AUTH_CLIENT_KEY,
+                    ClientKeys.AUTH_CLIENT_SECRET);
 
             EcovacsApi api = new EcovacsApi(httpClientFactory.getCommonHttpClient(), new Gson(), apiConfig);
             try {


### PR DESCRIPTION
I moved the client keys and secrets to the api configuration. 
With that we can make them configurable by the user . It will allow for more flexibility and we can provide support in case of one of the keys or secrets becomming invalid, 
Further on we will need to provide information on how to get those keys and secrets.